### PR TITLE
Support 0.5 models

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: jar
         path: build/libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.2.0
 
-* Support for QuPath v0.5.0
+* Support for QuPath v0.6.0
 
 ## v0.1.0
 

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -37,6 +37,7 @@ import org.bytedeco.opencv.opencv_core.Mat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -59,8 +60,6 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.util.StringConverter;
-import qupath.bioimageio.spec.BioimageIoParsing;
-import qupath.bioimageio.spec.BioimageIoSpec.BioimageIoModel;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.imagej.tools.IJTools;
@@ -82,6 +81,8 @@ import qupath.opencv.ops.ImageOps;
 import qupath.opencv.tools.NumpyTools;
 import qupath.opencv.tools.OpenCVTools;
 
+import qupath.bioimageio.spec.Model;
+import qupath.bioimageio.spec.tensor.axes.Axis;
 
 
 /**
@@ -114,7 +115,7 @@ public class BioimageIoCommand {
 		
 		boolean showLoadPixelClassifier = false;
 		try {
-			var model = BioimageIoParsing.parseModel(file);
+			var model = Model.parseModel(file);
 						
 			var params = new DnnBuilderPane(qupath, title)
 					.promptForParameters(model, qupath.getImageData());
@@ -177,7 +178,7 @@ public class BioimageIoCommand {
 	
 	static void showDialog(ImageData<?> imageData, String path) throws IOException {
 		
-		var model = BioimageIoParsing.parseModel(Paths.get(path));
+		var model = Model.parseModel(Paths.get(path));
 		
 		var params = new DnnBuilderPane(QuPathGUI.getInstance(), title)
 				.promptForParameters(model, imageData);
@@ -205,13 +206,13 @@ public class BioimageIoCommand {
 			this.title = title;
 		}
 
-		private PatchClassifierParams promptForParameters(BioimageIoModel model, ImageData<?> imageData) {
+		private PatchClassifierParams promptForParameters(Model model, ImageData<?> imageData) {
 			
 			Objects.requireNonNull(imageData, "ImageData must not be null!");
 			
 			// Parse the parameters
 			var params = BioimageIoTools.buildPatchClassifierParams(model);
-			
+
 			// Create a builder so that we can update parameters
 			var builder = PatchClassifierParams.builder(params);
 			
@@ -310,7 +311,7 @@ public class BioimageIoCommand {
 				int[] shape = output.getShape().getShape();				
 				int[] steps = output.getShape().getShapeStep();				
 				int[] minSize = output.getShape().getShapeMin();
-				String outputAxes = BioimageIoSpec.getAxesString(output.getAxes()).toLowerCase();
+				String outputAxes = Axis.getAxesString(output.getAxes()).toLowerCase();
 				int indX = outputAxes.indexOf("x");
 				int indY = outputAxes.indexOf("y");
 				if (indX >= 0 && indY >= 0) {
@@ -485,11 +486,11 @@ public class BioimageIoCommand {
 		
 		private static final Logger logger = LoggerFactory.getLogger(BioimageIoTest.class);
 		
-		private BioimageIoModel model;
+		private Model model;
 		private Mat matInput;
 		private Mat matOutput;
 		
-		private BioimageIoTest(BioimageIoModel model) {
+		private BioimageIoTest(Model model) {
 			this.model = model;
 			var testInputs = model.getTestInputs();
 			var testOutputs = model.getTestOutputs();

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import qupath.bioimageio.spec.Model;
 import qupath.bioimageio.spec.tensor.axes.Axes;
 import qupath.bioimageio.spec.tensor.axes.Axis;
+import qupath.bioimageio.spec.tensor.axes.AxisType;
 import qupath.fx.dialogs.Dialogs;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.fx.utils.GridPaneUtils;
@@ -67,7 +68,6 @@ import qupath.opencv.ops.ImageOp;
 import qupath.opencv.ops.ImageOps;
 import qupath.opencv.tools.NumpyTools;
 import qupath.opencv.tools.OpenCVTools;
-import qupath.bioimageio.spec.tensor.axes.SpaceAxes.SpaceAxis;
 
 import javax.swing.SwingUtilities;
 import java.io.IOException;
@@ -123,7 +123,7 @@ public class BioimageIoCommand {
 				return;
 			}
 			var inputAxes = inputs.getFirst().getAxes();
-			var spaceAxes = Arrays.stream(inputAxes).filter(ax -> ax instanceof SpaceAxis).toList();
+			var spaceAxes = Arrays.stream(inputAxes).filter(BioimageIoCommand::isSpaceAxis).toList();
 			if (spaceAxes.size() > 2) {
 				Dialogs.showInfoNotification("BioImageIO", "This extension currently only supports 2D models.");
 				return;
@@ -185,6 +185,11 @@ public class BioimageIoCommand {
 			logger.error("Error loading model", e);
 		}
 	}
+
+	private static boolean isSpaceAxis(Axis ax) {
+		return ax.getType() == AxisType.X || ax.getType() == AxisType.Y || ax.getType() == AxisType.Z;
+	}
+
 
 	static void showDialog(ImageData<?> imageData, String path) throws IOException {
 		

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -539,11 +539,6 @@ class BioimageIoCommand {
 			}
 		}
 
-
-		/**
-		 *
-		 * @param params
-		 */
 		void runAndShowOutput(PatchClassifierParams params) {
 			if (matInput == null) {
 				logger.warn("Cannot run test - not input image found");
@@ -608,10 +603,7 @@ class BioimageIoCommand {
 		
 	}
 	
-	/**
-	 * Try to show ImageJ images.
-	 * @param imps The images.
-	 */
+
 	private static void tryToShowImages(Collection<? extends ImagePlus> imps) {
 		if (imps.isEmpty())
 			return;

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -89,7 +89,7 @@ import java.util.stream.Collectors;
  * 
  * @author Pete Bankhead
  */
-public class BioimageIoCommand {
+class BioimageIoCommand {
 	
 	private final static Logger logger = LoggerFactory.getLogger(BioimageIoCommand.class);
 	
@@ -103,7 +103,7 @@ public class BioimageIoCommand {
 	/**
 	 * Show a prompt to select a bioimage.io directory and show the prediction for the current image.
 	 */
-	public void promptForModel() {
+	void promptForModel() {
 		
 		// TODO: In the future consider handling .zip files
 		var file = FileChoosers.promptForFile(title,
@@ -123,8 +123,10 @@ public class BioimageIoCommand {
 				return;
 			}
 			var inputAxes = inputs.getFirst().getAxes();
-			var spaceAxes = Arrays.stream(inputAxes).filter(BioimageIoCommand::isSpaceAxis).toList();
-			if (spaceAxes.size() > 2) {
+			long nSpaceAxes = Arrays.stream(inputAxes)
+					.filter(BioimageIoCommand::isSpaceAxis)
+					.count();
+			if (nSpaceAxes > 2) {
 				Dialogs.showErrorMessage("Bioimage Model Zoo extension", "This extension currently only supports 2D models.");
 				return;
 			}
@@ -522,7 +524,7 @@ public class BioimageIoCommand {
 			}
 		}
 		
-		public boolean hasInput() {
+		boolean hasInput() {
 			return matInput != null;
 		}
 		
@@ -536,10 +538,13 @@ public class BioimageIoCommand {
 				return null;
 			}
 		}
-		
-		
-		
-		public void runAndShowOutput(PatchClassifierParams params) {
+
+
+		/**
+		 *
+		 * @param params
+		 */
+		void runAndShowOutput(PatchClassifierParams params) {
 			if (matInput == null) {
 				logger.warn("Cannot run test - not input image found");
 			}

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -119,13 +119,13 @@ public class BioimageIoCommand {
 			var inputs = model.getInputs();
 			var outputs = model.getOutputs();
 			if (inputs.size() > 1 || outputs.size() > 1) {
-				Dialogs.showInfoNotification("BioImageIO", "Unable to run models with more than one input or output.");
+				Dialogs.showErrorMessage("Bioimage Model Zoo extension", "Unable to run models with more than one input or output.");
 				return;
 			}
 			var inputAxes = inputs.getFirst().getAxes();
 			var spaceAxes = Arrays.stream(inputAxes).filter(BioimageIoCommand::isSpaceAxis).toList();
 			if (spaceAxes.size() > 2) {
-				Dialogs.showInfoNotification("BioImageIO", "This extension currently only supports 2D models.");
+				Dialogs.showErrorMessage("Bioimage Model Zoo extension", "This extension currently only supports 2D models.");
 				return;
 			}
 			var params = new DnnBuilderPane(qupath, title)

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -16,30 +16,6 @@
 
 package qupath.ext.bioimageio;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import javax.swing.SwingUtilities;
-
-import javafx.stage.FileChooser;
-import org.bytedeco.javacpp.PointerScope;
-import org.bytedeco.opencv.global.opencv_core;
-import org.bytedeco.opencv.opencv_core.Mat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -61,15 +37,22 @@ import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
+import javafx.stage.FileChooser;
 import javafx.util.StringConverter;
+import org.bytedeco.javacpp.PointerScope;
+import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.bioimageio.spec.Model;
+import qupath.bioimageio.spec.tensor.axes.Axes;
 import qupath.bioimageio.spec.tensor.axes.Axis;
-import qupath.bioimageio.spec.tensor.axes.AxisType;
+import qupath.fx.dialogs.Dialogs;
 import qupath.fx.dialogs.FileChoosers;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.imagej.tools.IJTools;
 import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
-import qupath.fx.dialogs.Dialogs;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ColorTransforms;
 import qupath.lib.images.servers.ColorTransforms.ColorTransform;
@@ -84,9 +67,21 @@ import qupath.opencv.ops.ImageOp;
 import qupath.opencv.ops.ImageOps;
 import qupath.opencv.tools.NumpyTools;
 import qupath.opencv.tools.OpenCVTools;
+import qupath.bioimageio.spec.tensor.axes.SpaceAxes.SpaceAxis;
 
-import qupath.bioimageio.spec.Model;
-import qupath.bioimageio.spec.tensor.axes.Axes;
+import javax.swing.SwingUtilities;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 
 /**
@@ -128,7 +123,7 @@ public class BioimageIoCommand {
 				return;
 			}
 			var inputAxes = inputs.getFirst().getAxes();
-			var spaceAxes = Arrays.stream(inputAxes).filter(BioimageIoCommand::isSpaceAxis).toList();
+			var spaceAxes = Arrays.stream(inputAxes).filter(ax -> ax instanceof SpaceAxis).toList();
 			if (spaceAxes.size() > 2) {
 				Dialogs.showInfoNotification("BioImageIO", "This extension currently only supports 2D models.");
 				return;
@@ -190,11 +185,6 @@ public class BioimageIoCommand {
 			logger.error("Error loading model", e);
 		}
 	}
-
-	private static boolean isSpaceAxis(Axis ax) {
-		return ax.getType() == AxisType.X || ax.getType() == AxisType.Y || ax.getType() == AxisType.Z;
-	}
-
 
 	static void showDialog(ImageData<?> imageData, String path) throws IOException {
 		

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -82,7 +82,7 @@ import qupath.opencv.tools.NumpyTools;
 import qupath.opencv.tools.OpenCVTools;
 
 import qupath.bioimageio.spec.Model;
-import qupath.bioimageio.spec.tensor.axes.Axis;
+import qupath.bioimageio.spec.tensor.axes.Axes;
 
 
 /**
@@ -108,14 +108,14 @@ public class BioimageIoCommand {
 		
 		// TODO: In the future consider handling .zip files
 		var file = FileChoosers.promptForFile(title,
-				FileChoosers.createExtensionFilter("BioImage Model Zoo YAML file", "*.yml", "*.yaml"));
+				FileChoosers.createExtensionFilter("Bioimage Model Zoo YAML file", "*.yml", "*.yaml"));
 		if (file == null)
 			return;
 		
 		
 		boolean showLoadPixelClassifier = false;
 		try {
-			var model = Model.parseModel(file);
+			var model = Model.parse(file);
 						
 			var params = new DnnBuilderPane(qupath, title)
 					.promptForParameters(model, qupath.getImageData());
@@ -178,7 +178,7 @@ public class BioimageIoCommand {
 	
 	static void showDialog(ImageData<?> imageData, String path) throws IOException {
 		
-		var model = Model.parseModel(Paths.get(path));
+		var model = Model.parse(Paths.get(path));
 		
 		var params = new DnnBuilderPane(QuPathGUI.getInstance(), title)
 				.promptForParameters(model, imageData);
@@ -311,7 +311,7 @@ public class BioimageIoCommand {
 				int[] shape = output.getShape().getShape();				
 				int[] steps = output.getShape().getShapeStep();				
 				int[] minSize = output.getShape().getShapeMin();
-				String outputAxes = Axis.getAxesString(output.getAxes()).toLowerCase();
+				String outputAxes = Axes.getAxesString(output.getAxes()).toLowerCase();
 				int indX = outputAxes.indexOf("x");
 				int indY = outputAxes.indexOf("y");
 				if (indX >= 0 && indY >= 0) {

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoExtension.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoExtension.java
@@ -78,7 +78,7 @@ public class BioimageIoExtension implements QuPathExtension, GitHubProject {
 
 	@Override
 	public Version getQuPathVersion() {
-		return Version.parse("0.5.0");
+		return Version.parse("0.6.0");
 	}
 
 }


### PR DESCRIPTION
Fairly minimal changes as the updated model spec tries to be transparent, but took the time to replace some deprecated calls.

Adds checks for our stated support (2D images with one input and output)

I was concerned about handling multiple inputs and outputs in `BioimageIoTest` , but I realise now that:

- you can already have multiple inputs and outputs in 0.4 and we definitely don't handle those
- we would have to completely refactor how classification is done to handle these anyway! (I think... maybe I underestimate the flexibility of DnnModel etc)

I've tested with the broad U-net model and the top 8 models on the model zoo. All of the 2 models work.