### PR TITLE
Separate UI layout from logic and improve pixel size handling

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 qupath {
-	version = "0.7.0"
+	version = "0.7.1"
 }
 
 // Apply QuPath Gradle settings plugin to handle configuration

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -19,6 +19,7 @@ package qupath.ext.bioimageio;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
+import java.util.ResourceBundle;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -26,6 +27,7 @@ import javafx.event.ActionEvent;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
@@ -38,6 +40,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 import javafx.stage.FileChooser;
+import javafx.stage.Stage;
 import javafx.util.StringConverter;
 import org.bytedeco.javacpp.PointerScope;
 import org.bytedeco.opencv.global.opencv_core;
@@ -92,10 +95,11 @@ import java.util.stream.Collectors;
 class BioimageIoCommand {
 	
 	private final static Logger logger = LoggerFactory.getLogger(BioimageIoCommand.class);
-	
+	private static final ResourceBundle resources = ResourceBundle.getBundle("qupath.ext.bioimageio.strings");
+
 	private final QuPathGUI qupath;
 	private static final String title = "Bioimage.io to Pixel Classifier";
-	
+
 	BioimageIoCommand(QuPathGUI qupath) {
 		this.qupath = qupath;
 	}
@@ -130,56 +134,64 @@ class BioimageIoCommand {
 				Dialogs.showErrorMessage("Bioimage Model Zoo extension", "This extension currently only supports 2D models.");
 				return;
 			}
-			var params = new DnnBuilderPane(qupath, title)
-					.promptForParameters(model, qupath.getImageData());
-			
-			if (params == null)
-				return;
-			
-			var classifier = PatchClassifierParams.buildPixelClassifier(params);
-			if (classifier == null) {
-				logger.info("No pixel classifier created!");
-				return;
-			}
-			
-			// Try to save in the current project
-			var project = qupath.getProject();
-			if (project != null) {
-				var name = Dialogs.showInputDialog(title, "Choose classifier name", model.getName());
-				if (name != null) {
-					Dialogs.showInfoNotification(title, "Pixel classifier saved as " + name);
-					project.getPixelClassifiers().put(name, classifier);
-					showLoadPixelClassifier = true;
-				}
-			} else {
-				var fileSaved = FileChoosers.promptToSaveFile(title,
-						FileChoosers.promptToSaveFile(new FileChooser.ExtensionFilter("Pixel classifier", "*.json")));
-				if (fileSaved != null) {
-					PixelClassifiers.writeClassifier(classifier, fileSaved.toPath());
-					Dialogs.showInfoNotification(title, "Pixel classifier saved to \n" + fileSaved.getAbsolutePath());
-				}
-			}
-			
+			var pane = BioimageIoPane.createInstance(qupath, model);
+			Stage s = new Stage();
+			s.setTitle(resources.getString("title"));
+			Scene ss = new Scene(pane);
+			s.setScene(ss);
+			s.show();
+			return;
 
-			// Offer to show the prediction in the current image, if it's small enough
-			var imageData = qupath.getImageData();
-			if (imageData != null) {
-				var classifierServer = PixelClassifierTools.createPixelClassificationServer(imageData, classifier);
-				int maxSize = 4096;
-				if (classifierServer.getWidth() < maxSize && classifierServer.getHeight() < maxSize) {
-					if (Dialogs.showYesNoDialog(title, "Apply prediction & open in ImageJ?")) {
-						var imp = IJTools.extractHyperstack(classifierServer, null);
-						tryToShowImages(Collections.singleton(imp));
-					}
-				}
-			}
-			
-			if (showLoadPixelClassifier) {
-				// Try to show 'Load pixel classifier' dialog
-				var action = qupath.lookupActionByText("Load pixel classifier...");
-				if (action != null && !action.isDisabled())
-					action.handle(new ActionEvent());
-			}
+//			var params = new DnnBuilderPane(qupath, title)
+//					.promptForParameters(model, qupath.getImageData());
+//
+//			if (params == null)
+//				return;
+//
+//			var classifier = PatchClassifierParams.buildPixelClassifier(params);
+//			if (classifier == null) {
+//				logger.info("No pixel classifier created!");
+//				return;
+//			}
+//
+//			// Try to save in the current project
+//			var project = qupath.getProject();
+//			if (project != null) {
+//				var name = Dialogs.showInputDialog(title, "Choose classifier name", model.getName());
+//				if (name != null) {
+//					Dialogs.showInfoNotification(title, "Pixel classifier saved as " + name);
+//					project.getPixelClassifiers().put(name, classifier);
+//					showLoadPixelClassifier = true;
+//				}
+//			} else {
+//				var fileSaved = FileChoosers.promptToSaveFile(title,
+//						FileChoosers.promptToSaveFile(new FileChooser.ExtensionFilter("Pixel classifier", "*.json")));
+//				if (fileSaved != null) {
+//					PixelClassifiers.writeClassifier(classifier, fileSaved.toPath());
+//					Dialogs.showInfoNotification(title, "Pixel classifier saved to \n" + fileSaved.getAbsolutePath());
+//				}
+//			}
+//
+//
+//			// Offer to show the prediction in the current image, if it's small enough
+//			var imageData = qupath.getImageData();
+//			if (imageData != null) {
+//				var classifierServer = PixelClassifierTools.createPixelClassificationServer(imageData, classifier);
+//				int maxSize = 4096;
+//				if (classifierServer.getWidth() < maxSize && classifierServer.getHeight() < maxSize) {
+//					if (Dialogs.showYesNoDialog(title, "Apply prediction & open in ImageJ?")) {
+//						var imp = IJTools.extractHyperstack(classifierServer, null);
+//						tryToShowImages(Collections.singleton(imp));
+//					}
+//				}
+//			}
+//
+//			if (showLoadPixelClassifier) {
+//				// Try to show 'Load pixel classifier' dialog
+//				var action = qupath.lookupActionByText("Load pixel classifier...");
+//				if (action != null && !action.isDisabled())
+//					action.handle(new ActionEvent());
+//			}
 
 			
 		} catch (Exception e) {
@@ -292,33 +304,30 @@ class BioimageIoCommand {
 					builder.inputChannels(inputChannels);
 				});
 			}
-			
+
+			double pixelSize = 1; // todo get current pixel size
+
 			// Handle pixel size
 			var cal = server.getPixelCalibration();
 			addTitleRow(pane, "Input resolution", row++);
-			addDescriptionRow(pane, "The pixel size at which the model will be applied", row++);
-			var factoryDownsample = new SpinnerValueFactory.DoubleSpinnerValueFactory(1.0, Double.MAX_VALUE, 1.0, 0.1);
-			var spinnerDownsample = new Spinner<>(factoryDownsample);
-			spinnerDownsample.setEditable(true);
-			GridPaneUtils.setToExpandGridPaneWidth(spinnerDownsample);
-			addLabeledRow(pane, "Downsample", row++, "Choose downsample for input image", spinnerDownsample);
+			addDescriptionRow(pane, "The pixel size in microns at which the model will be applied", row++);
+			var factoryPixelSize = new SpinnerValueFactory.DoubleSpinnerValueFactory(1.0, Double.MAX_VALUE, pixelSize, 0.1);
+			var spinnerPixelSize = new Spinner<>(factoryPixelSize);
+			spinnerPixelSize.setEditable(true);
+			GridPaneUtils.setToExpandGridPaneWidth(spinnerPixelSize);
+			addLabeledRow(pane, "Pixel size", row++, "Choose pixel size for input image", spinnerPixelSize);
 			var labelResolution = new Label(calToString(cal, 1));
 			labelResolution.textProperty().bind(Bindings.createStringBinding(() -> {
-				Double scale = spinnerDownsample.getValue();
+				Double scale = spinnerPixelSize.getValue();
 				if (scale == null || scale < 1)
 					scale = 1.0;
 				return calToString(cal, scale);
-			}, spinnerDownsample.valueProperty()));
-			spinnerDownsample.valueProperty().addListener((v, o, n) -> {
-				if (n >= 1.0)
-					builder.inputResolution(cal, n);
-			});
-			addLabeledRow(pane, "Calculated resolution", row++, "Input resolution, calculated from the current image and downsample value", labelResolution);
-			
+			}, spinnerPixelSize.valueProperty()));
+
 			// Handle tile shape
 			addTitleRow(pane, "Input tile shape", row++);
 			addDescriptionRow(pane, "The size of each input tile when processing large images", row++);
-			
+
 			// Use the patch values by default, but try to offer all the options from the model spec
 			int width = params.getPatchWidth();
 			int height = params.getPatchHeight();
@@ -401,7 +410,8 @@ class BioimageIoCommand {
 			// Handle output type
 			addTitleRow(pane, "Output type", row++);
 			addDescriptionRow(pane, "The output type of the model", row++);
-			
+
+			// todo: does feature/density/channel ever make sense?
 			var comboOutputType = new ComboBox<ChannelType>();
 			comboOutputType.getItems().setAll(ChannelType.values());
 			comboOutputType.getSelectionModel().select(params.getOutputChannelType());

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -20,28 +20,8 @@ import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
 import java.util.ResourceBundle;
-import javafx.beans.binding.Bindings;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
-import javafx.geometry.Insets;
-import javafx.geometry.Orientation;
-import javafx.scene.Node;
-import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.Separator;
-import javafx.scene.control.Spinner;
-import javafx.scene.control.SpinnerValueFactory;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.GridPane;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
 import javafx.stage.FileChooser;
-import javafx.stage.Stage;
 import javafx.util.StringConverter;
 import org.bytedeco.javacpp.PointerScope;
 import org.bytedeco.opencv.global.opencv_core;
@@ -49,23 +29,13 @@ import org.bytedeco.opencv.opencv_core.Mat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.bioimageio.spec.Model;
-import qupath.bioimageio.spec.tensor.axes.Axes;
 import qupath.bioimageio.spec.tensor.axes.Axis;
 import qupath.bioimageio.spec.tensor.axes.AxisType;
 import qupath.fx.dialogs.Dialogs;
 import qupath.fx.dialogs.FileChoosers;
-import qupath.fx.utils.FXUtils;
-import qupath.fx.utils.GridPaneUtils;
 import qupath.imagej.tools.IJTools;
-import qupath.lib.common.GeneralTools;
 import qupath.lib.gui.QuPathGUI;
-import qupath.lib.images.ImageData;
-import qupath.lib.images.servers.ColorTransforms;
-import qupath.lib.images.servers.ColorTransforms.ColorTransform;
-import qupath.lib.images.servers.ImageServerMetadata.ChannelType;
-import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.objects.classes.PathClass;
-import qupath.opencv.ml.BioimageIoTools;
 import qupath.opencv.ml.PatchClassifierParams;
 import qupath.opencv.ml.pixel.PixelClassifierTools;
 import qupath.opencv.ml.pixel.PixelClassifiers;
@@ -83,10 +53,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 
 /**
@@ -101,7 +69,6 @@ class BioimageIoCommand {
 
 	private final QuPathGUI qupath;
 	private static final String title = "Bioimage.io to Pixel Classifier";
-	private Stage stage;
 
 	BioimageIoCommand(QuPathGUI qupath) {
 		this.qupath = qupath;
@@ -140,9 +107,6 @@ class BioimageIoCommand {
 
 			var params = BioimageIoPane.createDialog(qupath, model);
 
-//			var params = new DnnBuilderPane(qupath, title)
-//					.promptForParameters(model, qupath.getImageData());
-//
 			if (params == null)
 				return;
 
@@ -203,300 +167,12 @@ class BioimageIoCommand {
 		return ax.getType() == AxisType.X || ax.getType() == AxisType.Y || ax.getType() == AxisType.Z;
 	}
 
-	static class DnnBuilderPane {
-		
-		private final QuPathGUI qupath;
-		private final String title;
-		
-		private static final Font font = Font.font("Arial");
-		
-		private DnnBuilderPane(QuPathGUI qupath, String title) {
-			this.qupath = qupath;
-			this.title = title;
-		}
 
-		private PatchClassifierParams promptForParameters(Model model, ImageData<?> imageData) {
-			
-			Objects.requireNonNull(imageData, "ImageData must not be null!");
-			
-			// Parse the parameters
-			var params = BioimageIoTools.buildPatchClassifierParams(model);
-
-			// Create a builder so that we can update parameters
-			var builder = PatchClassifierParams.builder(params);
-			
-			int nChannels = params.getInputChannels().size();
-			int nOutputClasses = params.getOutputClasses().size();
-
-			GridPane pane = new GridPane();
-			pane.setHgap(5);
-			pane.setVgap(5);
-			
-			int row = 0;
-			
-			addTitleRow(pane, "Experimental - use with caution!", row++);
-			addDescriptionRow(pane,
-					"This command tries to create a QuPath "
-					+ "pixel classifier from a BioImage Model Zoo spec."
-					, row++);
-			addDescriptionRow(pane,
-					"It may not work in all (or even most) cases."
-					, row++);
-			addDescriptionRow(pane,
-					"It can also sometimes give different results to "
-					+ "other software, because of different per-tile normalization."
-					, row++);
-			
-			addSeparatorRow(pane, row++);
-
-			// Handle input channels & their order
-			addTitleRow(pane, "Input channels", row++);
-			addDescriptionRow(pane, "The image channels provided as input to the model", row++);
-			
-			var server = imageData.getServer();
-			ObservableList<ColorTransform> availableChannels = FXCollections.observableArrayList(
-						server.getMetadata().getChannels()
-							.stream()
-							.map(c -> ColorTransforms.createChannelExtractor(c.getName()))
-							.collect(Collectors.toList()));				
-			availableChannels.addAll(
-					ColorTransforms.createMeanChannelTransform(),
-					ColorTransforms.createMaximumChannelTransform(),
-					ColorTransforms.createMinimumChannelTransform()
-					);
-			
-			List<ColorTransform> inputChannels = new ArrayList<>();
-			for (int c = 1; c <= nChannels; c++) {
-				var comboChannel = new ComboBox<>(availableChannels);
-				comboChannel.getSelectionModel().select((c-1) % availableChannels.size());
-				inputChannels.add(comboChannel.getSelectionModel().getSelectedItem());
-
-				GridPaneUtils.setToExpandGridPaneWidth(comboChannel);
-				addLabeledRow(pane, "Channel "+c, row++, "Choose channel " + c + " input", comboChannel);
-				
-				int ind = c - 1;
-				comboChannel.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
-					if (n == null) {
-						logger.warn("Cannot set channel to null");
-						return;
-					}
-					inputChannels.set(ind, n);
-					builder.inputChannels(inputChannels);
-				});
-			}
-
-			double pixelSize = 1; // todo get current pixel size
-
-			// Handle pixel size
-			var cal = server.getPixelCalibration();
-			addTitleRow(pane, "Input resolution", row++);
-			addDescriptionRow(pane, "The pixel size in microns at which the model will be applied", row++);
-			var factoryPixelSize = new SpinnerValueFactory.DoubleSpinnerValueFactory(1.0, Double.MAX_VALUE, pixelSize, 0.1);
-			var spinnerPixelSize = new Spinner<>(factoryPixelSize);
-			spinnerPixelSize.setEditable(true);
-			GridPaneUtils.setToExpandGridPaneWidth(spinnerPixelSize);
-			addLabeledRow(pane, "Pixel size", row++, "Choose pixel size for input image", spinnerPixelSize);
-			var labelResolution = new Label(calToString(cal, 1));
-			labelResolution.textProperty().bind(Bindings.createStringBinding(() -> {
-				Double scale = spinnerPixelSize.getValue();
-				if (scale == null || scale < 1)
-					scale = 1.0;
-				return calToString(cal, scale);
-			}, spinnerPixelSize.valueProperty()));
-
-			// Handle tile shape
-			addTitleRow(pane, "Input tile shape", row++);
-			addDescriptionRow(pane, "The size of each input tile when processing large images", row++);
-
-			// Use the patch values by default, but try to offer all the options from the model spec
-			int width = params.getPatchWidth();
-			int height = params.getPatchHeight();
-			int stepWidth = 0;
-			int stepHeight = 0;
-			if (model.getOutputs().size() == 1) {
-				var output = model.getOutputs().get(0);
-				int[] shape = output.getShape().getShape();				
-				int[] steps = output.getShape().getShapeStep();				
-				int[] minSize = output.getShape().getShapeMin();
-				String outputAxes = Axes.getAxesString(output.getAxes()).toLowerCase();
-				int indX = outputAxes.indexOf("x");
-				int indY = outputAxes.indexOf("y");
-				if (indX >= 0 && indY >= 0) {
-					if (minSize.length > 0) {
-						width = minSize[indX];
-						height = minSize[indY];
-					} else if (shape.length > 0) {
-						width = shape[indX];
-						height = shape[indY];
-					}
-					if (steps.length > 0) {
-						stepWidth = steps[indX];
-						stepHeight = steps[indY];
-					}
-				}
-			}
-			if (stepWidth > 0 || stepHeight > 0) {
-				int maxTile = Math.max(width, height) * 8;
-				var factoryWidth = new SpinnerValueFactory.IntegerSpinnerValueFactory(0, maxTile);
-				factoryWidth.setValue(params.getPatchWidth());
-				factoryWidth.setAmountToStepBy(stepWidth);
-				var spinnerWidth = new Spinner<>(factoryWidth);
-				
-				var factoryHeight = new SpinnerValueFactory.IntegerSpinnerValueFactory(0, maxTile);
-				factoryHeight.setValue(params.getPatchHeight());
-				// TODO: Incorporate step size, if available
-				factoryHeight.setAmountToStepBy(stepHeight);
-				var spinnerHeight = new Spinner<>(factoryHeight);
-
-				GridPaneUtils.setToExpandGridPaneWidth(spinnerWidth, spinnerHeight);
-				addLabeledRow(pane, "Tile width", row++, "Choose input tile width in pixels", spinnerWidth);
-				addLabeledRow(pane, "Tile height", row++, "Choose input tile height in pixels", spinnerHeight);
-				spinnerWidth.setEditable(false);
-				spinnerHeight.setEditable(false);
-				spinnerWidth.valueProperty().addListener((v, o, n) -> builder.patchSize(spinnerWidth.getValue(), spinnerHeight.getValue()));
-				spinnerHeight.valueProperty().addListener((v, o, n) -> builder.patchSize(spinnerWidth.getValue(), spinnerHeight.getValue()));
-				GridPaneUtils.setToExpandGridPaneWidth(spinnerWidth, spinnerHeight, labelResolution);
-			} else {
-				addDescriptionRow(pane, String.format("Tile size fixed to %d x %d", width, height), row++);
-			}
-			
-			// Handle output
-			addTitleRow(pane, "Output classes", row++);
-			addDescriptionRow(pane, "The classifications corresponding to the model output", row++);
-			GridPaneUtils.setToExpandGridPaneWidth(labelResolution);
-
-			ObservableList<PathClass> availableClasses = FXCollections.observableArrayList();
-			if (qupath != null)
-				availableClasses = qupath.getAvailablePathClasses();
-			
-			var outputClasses = new LinkedHashMap<>(params.getOutputClasses());
-			ObservableList<PathClass> classList = FXCollections.observableArrayList(outputClasses.values());
-			for (int c = 1; c <= nOutputClasses; c++) {
-				var comboOutputClasses = new ComboBox<>(classList);
-				comboOutputClasses.getItems().addAll(availableClasses);
-				comboOutputClasses.setEditable(true);
-				comboOutputClasses.setConverter(new PathClassStringConverter());
-				if (c <= availableClasses.size())
-					comboOutputClasses.getSelectionModel().select(c-1);
-				GridPaneUtils.setToExpandGridPaneWidth(comboOutputClasses);
-				addLabeledRow(pane, "Class "+c, row++, "Choose output classification for channel " + c, comboOutputClasses);
-				int ind = c - 1;
-				comboOutputClasses.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
-					outputClasses.put(ind, n);
-					builder.outputClasses(outputClasses);
-				});
-			}
-			
-			// Handle output type
-			addTitleRow(pane, "Output type", row++);
-			addDescriptionRow(pane, "The output type of the model", row++);
-
-			// todo: does feature/density/channel ever make sense?
-			var comboOutputType = new ComboBox<ChannelType>();
-			comboOutputType.getItems().setAll(ChannelType.values());
-			comboOutputType.getSelectionModel().select(params.getOutputChannelType());
-			comboOutputType.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
-				if (n != null)
-					builder.outputChannelType(n);
-				else
-					logger.warn("Output type cannot be null");
-			});
-
-			GridPaneUtils.setToExpandGridPaneWidth(comboOutputType);
-			addLabeledRow(pane, "Output", row++, "Choose output type", comboOutputType);
-			
-			var tester = new BioimageIoTest(model);
-			if (tester.hasInput()) {
-				var btnTest = new Button("Show test images in ImageJ");
-				btnTest.setOnAction(e -> tester.runAndShowOutput(params));
-				GridPaneUtils.addGridRow(pane, row++, 0,
-						"Attempt to run prediction on the test image, if available.\n"
-								+ "This checks the model runes, but does not use most of the customizations here\n"
-								+ "because the channel input is fixed.",
-						btnTest, btnTest);
-				GridPaneUtils.setToExpandGridPaneWidth(btnTest);
-			}
-			
-			var scrollPane = new ScrollPane(pane);
-			scrollPane.setFitToWidth(true);
-			var result = Dialogs.builder()
-					.title(title)
-					.content(scrollPane)
-					.buttons(ButtonType.CANCEL, ButtonType.APPLY)
-					.prefHeight(500) // Setting height & resizable deal with dialogs that are too 'tall'
-					.prefWidth(400)
-					.resizable()
-					.showAndWait()
-					.orElse(ButtonType.CANCEL);
-				
-			tester.close();
-			
-			if (result.equals(ButtonType.CANCEL))
-				return null;
-			
-			return builder.build();
-		}
-		
-		
-		private static String calToString(PixelCalibration cal, double downsample) {
-			int ndp = 4;
-			return String.format("%s %s x %s %s",
-					GeneralTools.formatNumber(cal.getPixelWidth().doubleValue() * downsample, ndp), 
-					cal.getPixelWidthUnit(),
-					GeneralTools.formatNumber(cal.getPixelHeight().doubleValue() * downsample, ndp),
-					cal.getPixelHeightUnit());
-		}
-		
-		private static void addSeparatorRow(GridPane pane, int row) {
-			var sep = new Separator(Orientation.HORIZONTAL);
-			GridPane.setColumnSpan(sep, GridPane.REMAINING);
-			GridPaneUtils.setToExpandGridPaneWidth(sep);
-			GridPaneUtils.addGridRow(pane, row, 0, null, sep, sep);
-		}
-		
-		private static void addTitleRow(GridPane pane, String labelText, int row) {
-			addTextRow(pane, labelText, row, true);
-		}
-		
-		private static void addDescriptionRow(GridPane pane, String labelText, int row) {
-			addTextRow(pane, labelText, row, false);
-		}
-		
-		private static void addTextRow(GridPane pane, String labelText, int row, boolean isTitle) {
-			var label = new Label(labelText);
-			if (isTitle) {
-				label.setFont(Font.font(font.getFamily(), FontWeight.BOLD, font.getSize()));
-				label.setPadding(new Insets(10, 0, 0, 0));
-			} else
-				label.setWrapText(true);
-			pane.add(label, 0, row, GridPane.REMAINING, 1);
-		}
-		
-		private static void addLabeledRow(GridPane pane, String labelText, int row, String tooltip, Node... nodes) {
-			var label = new Label(labelText);
-			if (nodes.length == 0) {
-				GridPaneUtils.addGridRow(pane, row, 0, tooltip, label);
-			} else {
-				label.setLabelFor(nodes[0]);
-				if (nodes.length == 1)
-					GridPaneUtils.addGridRow(pane, row, 0, tooltip, label, nodes[0]);
-				else {
-					var nodes2 = new Node[nodes.length+1];
-					nodes2[0] = label;
-					System.arraycopy(nodes, 0, nodes2, 1, nodes.length);
-					GridPaneUtils.addGridRow(pane, row, 0, tooltip, nodes2);
-				}
-			}
-		}
-
-	}
-	
-	
 	static class BioimageIoTest implements AutoCloseable {
 		
 		private static final Logger logger = LoggerFactory.getLogger(BioimageIoTest.class);
 		
-		private Model model;
+		private final Model model;
 		private Mat matInput;
 		private Mat matOutput;
 		
@@ -508,11 +184,11 @@ class BioimageIoCommand {
 			if (baseUri == null)
 				return;
 			if (!testInputs.isEmpty()) {
-				var pathInput = Paths.get(baseUri.resolve(testInputs.get(0)));
+				var pathInput = Paths.get(baseUri.resolve(testInputs.getFirst()));
 				matInput = tryToReadMat(pathInput);
 			}
 			if (!testOutputs.isEmpty()) {
-				var pathOutput = Paths.get(baseUri.resolve(testOutputs.get(0)));
+				var pathOutput = Paths.get(baseUri.resolve(testOutputs.getFirst()));
 				matOutput = tryToReadMat(pathOutput);
 			}
 		}

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -176,7 +176,7 @@ class BioimageIoCommand {
 		private Mat matInput;
 		private Mat matOutput;
 		
-		private BioimageIoTest(Model model) {
+		BioimageIoTest(Model model) {
 			this.model = model;
 			var testInputs = model.getTestInputs();
 			var testOutputs = model.getTestOutputs();

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoCommand.java
@@ -36,6 +36,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Separator;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
@@ -53,6 +54,7 @@ import qupath.bioimageio.spec.tensor.axes.Axis;
 import qupath.bioimageio.spec.tensor.axes.AxisType;
 import qupath.fx.dialogs.Dialogs;
 import qupath.fx.dialogs.FileChoosers;
+import qupath.fx.utils.FXUtils;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.imagej.tools.IJTools;
 import qupath.lib.common.GeneralTools;
@@ -99,6 +101,7 @@ class BioimageIoCommand {
 
 	private final QuPathGUI qupath;
 	private static final String title = "Bioimage.io to Pixel Classifier";
+	private Stage stage;
 
 	BioimageIoCommand(QuPathGUI qupath) {
 		this.qupath = qupath;
@@ -134,64 +137,59 @@ class BioimageIoCommand {
 				Dialogs.showErrorMessage("Bioimage Model Zoo extension", "This extension currently only supports 2D models.");
 				return;
 			}
-			var pane = BioimageIoPane.createInstance(qupath, model);
-			Stage s = new Stage();
-			s.setTitle(resources.getString("title"));
-			Scene ss = new Scene(pane);
-			s.setScene(ss);
-			s.show();
-			return;
+
+			var params = BioimageIoPane.createDialog(qupath, model);
 
 //			var params = new DnnBuilderPane(qupath, title)
 //					.promptForParameters(model, qupath.getImageData());
 //
-//			if (params == null)
-//				return;
-//
-//			var classifier = PatchClassifierParams.buildPixelClassifier(params);
-//			if (classifier == null) {
-//				logger.info("No pixel classifier created!");
-//				return;
-//			}
-//
-//			// Try to save in the current project
-//			var project = qupath.getProject();
-//			if (project != null) {
-//				var name = Dialogs.showInputDialog(title, "Choose classifier name", model.getName());
-//				if (name != null) {
-//					Dialogs.showInfoNotification(title, "Pixel classifier saved as " + name);
-//					project.getPixelClassifiers().put(name, classifier);
-//					showLoadPixelClassifier = true;
-//				}
-//			} else {
-//				var fileSaved = FileChoosers.promptToSaveFile(title,
-//						FileChoosers.promptToSaveFile(new FileChooser.ExtensionFilter("Pixel classifier", "*.json")));
-//				if (fileSaved != null) {
-//					PixelClassifiers.writeClassifier(classifier, fileSaved.toPath());
-//					Dialogs.showInfoNotification(title, "Pixel classifier saved to \n" + fileSaved.getAbsolutePath());
-//				}
-//			}
-//
-//
-//			// Offer to show the prediction in the current image, if it's small enough
-//			var imageData = qupath.getImageData();
-//			if (imageData != null) {
-//				var classifierServer = PixelClassifierTools.createPixelClassificationServer(imageData, classifier);
-//				int maxSize = 4096;
-//				if (classifierServer.getWidth() < maxSize && classifierServer.getHeight() < maxSize) {
-//					if (Dialogs.showYesNoDialog(title, "Apply prediction & open in ImageJ?")) {
-//						var imp = IJTools.extractHyperstack(classifierServer, null);
-//						tryToShowImages(Collections.singleton(imp));
-//					}
-//				}
-//			}
-//
-//			if (showLoadPixelClassifier) {
-//				// Try to show 'Load pixel classifier' dialog
-//				var action = qupath.lookupActionByText("Load pixel classifier...");
-//				if (action != null && !action.isDisabled())
-//					action.handle(new ActionEvent());
-//			}
+			if (params == null)
+				return;
+
+			var classifier = PatchClassifierParams.buildPixelClassifier(params);
+			if (classifier == null) {
+				logger.info("No pixel classifier created!");
+				return;
+			}
+
+			// Try to save in the current project
+			var project = qupath.getProject();
+			if (project != null) {
+				var name = Dialogs.showInputDialog(title, "Choose classifier name", model.getName());
+				if (name != null) {
+					Dialogs.showInfoNotification(title, "Pixel classifier saved as " + name);
+					project.getPixelClassifiers().put(name, classifier);
+					showLoadPixelClassifier = true;
+				}
+			} else {
+				var fileSaved = FileChoosers.promptToSaveFile(title,
+						FileChoosers.promptToSaveFile(new FileChooser.ExtensionFilter("Pixel classifier", "*.json")));
+				if (fileSaved != null) {
+					PixelClassifiers.writeClassifier(classifier, fileSaved.toPath());
+					Dialogs.showInfoNotification(title, "Pixel classifier saved to \n" + fileSaved.getAbsolutePath());
+				}
+			}
+
+
+			// Offer to show the prediction in the current image, if it's small enough
+			var imageData = qupath.getImageData();
+			if (imageData != null) {
+				var classifierServer = PixelClassifierTools.createPixelClassificationServer(imageData, classifier);
+				int maxSize = 4096;
+				if (classifierServer.getWidth() < maxSize && classifierServer.getHeight() < maxSize) {
+					if (Dialogs.showYesNoDialog(title, "Apply prediction & open in ImageJ?")) {
+						var imp = IJTools.extractHyperstack(classifierServer, null);
+						tryToShowImages(Collections.singleton(imp));
+					}
+				}
+			}
+
+			if (showLoadPixelClassifier) {
+				// Try to show 'Load pixel classifier' dialog
+				var action = qupath.lookupActionByText("Load pixel classifier...");
+				if (action != null && !action.isDisabled())
+					action.handle(new ActionEvent());
+			}
 
 			
 		} catch (Exception e) {
@@ -200,29 +198,11 @@ class BioimageIoCommand {
 		}
 	}
 
+
 	private static boolean isSpaceAxis(Axis ax) {
 		return ax.getType() == AxisType.X || ax.getType() == AxisType.Y || ax.getType() == AxisType.Z;
 	}
 
-
-	static void showDialog(ImageData<?> imageData, String path) throws IOException {
-		
-		var model = Model.parse(Paths.get(path));
-		
-		var params = new DnnBuilderPane(QuPathGUI.getInstance(), title)
-				.promptForParameters(model, imageData);
-		
-		
-		var classifier = PatchClassifierParams.buildPixelClassifier(params);
-		if (classifier == null) {
-			logger.info("No pixel classifier created!");
-			return;
-		}
-		
-	}
-	
-
-	
 	static class DnnBuilderPane {
 		
 		private final QuPathGUI qupath;

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoExtension.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoExtension.java
@@ -20,6 +20,7 @@ import org.controlsfx.control.action.Action;
 
 import qupath.lib.common.Version;
 import qupath.lib.gui.QuPathGUI;
+import qupath.lib.gui.actions.annotations.ActionConfig;
 import qupath.lib.gui.actions.annotations.ActionMenu;
 import qupath.lib.gui.extensions.GitHubProject;
 import qupath.lib.gui.extensions.QuPathExtension;
@@ -27,16 +28,17 @@ import qupath.lib.gui.tools.MenuTools;
 
 /**
  * Extension to make some bioimage.io models available within QuPath.
- * Currently at an early stage of development and <b>very</b> limited...
+ * Currently, at an early stage of development and <b>very</b> limited...
  */
 public class BioimageIoExtension implements QuPathExtension, GitHubProject {
 
 	private boolean isInstalled = false;
 	
-//	@ActionConfig(value = "action", bundle = "qupath/ext/bioimageio/strings")
-	@ActionMenu("Extensions>BioImage Model Zoo...>Import pixel classifier (bioimage.io)")
+
+//	@ActionMenu("Extensions>BioImage Model Zoo...>Import pixel classifier (bioimage.io)")
+	@ActionConfig(value = "action", bundle = "qupath/ext/bioimageio/strings")
 	private Action actionBioimageIO;
-	
+
 	   @Override
     public void installExtension(QuPathGUI qupath) {
 		   if (isInstalled)
@@ -50,15 +52,6 @@ public class BioimageIoExtension implements QuPathExtension, GitHubProject {
 	                qupath.getMenu("Extensions>BioImage Model Zoo", true),
 	                actionBioimageIO
 	        );
-		   // TODO: Support drag & drop if we have a sensible dialog to use
-//		   qupath.getDefaultDragDropListener().addFileDropHandler((v, files) -> {
-//			   if (files.size() == 1 && files.get(0).isDirectory()) {
-//				   var dir = files.get(0);
-//				   if (new File(dir, SpecificationWriter.getModelFileName()).exists()) {
-//					   
-//				   }
-//			   }
-//		   });
     }
 
     @Override

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
@@ -70,10 +70,13 @@ public class BioimageIoPane extends BorderPane {
     @FXML
     private Button imageJButton;
 
+    private BioimageIoCommand.BioimageIoTest tester;
+
 
     public static PatchClassifierParams createDialog(QuPathGUI qupath, Model model) {
+        BioimageIoPane pane = null;
         try {
-			var pane = new BioimageIoPane(qupath, model);
+			pane = new BioimageIoPane(qupath, model);
 
 			var result = Dialogs.builder()
 					.title(resources.getString("title"))
@@ -92,7 +95,11 @@ public class BioimageIoPane extends BorderPane {
 		} catch (IOException e) {
 			Dialogs.showErrorMessage("BioimageIo", "GUI loading failed");
 			logger.error("Unable to load BioimageIo FXML", e);
-		}
+		} finally {
+            if (pane != null && pane.tester != null) {
+                pane.tester.close();
+            }
+        }
         return null;
     }
 
@@ -118,16 +125,9 @@ public class BioimageIoPane extends BorderPane {
     }
 
     private void configureImageJButton() {
-        var tester = new BioimageIoCommand.BioimageIoTest(model);
+        tester = new BioimageIoCommand.BioimageIoTest(model);
         if (tester.hasInput()) {
-            var btnTest = new Button("Show test images in ImageJ");
-            btnTest.setOnAction(e -> tester.runAndShowOutput(params));
-            GridPaneUtils.addGridRow(pane, row++, 0,
-                    "Attempt to run prediction on the test image, if available.\n"
-                            + "This checks the model runes, but does not use most of the customizations here\n"
-                            + "because the channel input is fixed.",
-                    btnTest, btnTest);
-            GridPaneUtils.setToExpandGridPaneWidth(btnTest);
+            imageJButton.setOnAction(e -> tester.runAndShowOutput(params));
         }
     }
 

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
@@ -1,6 +1,8 @@
 package qupath.ext.bioimageio;
 
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -11,6 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Pos;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
@@ -18,11 +21,15 @@ import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.util.StringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qupath.bioimageio.spec.Model;
 import qupath.bioimageio.spec.tensor.axes.Axes;
+import qupath.bioimageio.spec.tensor.axes.SpaceAxes;
+import qupath.fx.dialogs.Dialogs;
 import qupath.fx.utils.GridPaneUtils;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.images.ImageData;
@@ -57,16 +64,33 @@ public class BioimageIoPane extends BorderPane {
     private Spinner<Integer> tileHeightSpinner;
     @FXML
     private VBox tileShapeOptionsBox;
+    @FXML
+    private Spinner<Double> pixelSizeSpinner;
 
-    /**
-     * Create an instance of the InstanSeg GUI pane.
-     *
-     * @param qupath The QuPath GUI it should be attached to.
-     * @return A handle on the UI element.
-     * @throws IOException If the FXML or resources fail to load.
-     */
-    public static BioimageIoPane createInstance(QuPathGUI qupath, Model model) throws IOException {
-        return new BioimageIoPane(qupath, model);
+
+    public static PatchClassifierParams createDialog(QuPathGUI qupath, Model model) {
+        try {
+			var pane = new BioimageIoPane(qupath, model);
+
+			var result = Dialogs.builder()
+					.title(resources.getString("title"))
+					.content(pane)
+					.buttons(ButtonType.CANCEL, ButtonType.APPLY)
+					.prefHeight(500) // Setting height & resizable deal with dialogs that are too 'tall'
+					.prefWidth(400)
+                    .resizable()
+					.showAndWait()
+					.orElse(ButtonType.CANCEL);
+
+			if (result.equals(ButtonType.CANCEL))
+				return null;
+
+			return pane.builder.build();
+		} catch (IOException e) {
+			Dialogs.showErrorMessage("BioimageIo", "GUI loading failed");
+			logger.error("Unable to load BioimageIo FXML", e);
+		}
+        return null;
     }
 
 
@@ -84,8 +108,52 @@ public class BioimageIoPane extends BorderPane {
         var imageData = qupath.getImageData();
         configureInputChannels(imageData);
         configureTileSize();
+        configurePixelSize(model);
         configureOutputClasses();
         configureOutputTypes();
+    }
+
+    private void configurePixelSize(Model model) {
+        var axes = model.getInputs().getFirst().getAxes();
+        String axString = Axes.getAxesString(axes);
+        int xind = axString.indexOf("x");
+        int yind = axString.indexOf("y");
+        double xsize=0.25, ysize=0.25;
+        if (xind != -1 && yind != -1) {
+            if (axes[xind] instanceof SpaceAxes.SpaceAxis spaceAxis) {
+                if (spaceAxis.getUnit() != SpaceAxes.SpaceUnit.MICROMETER) {
+                    logger.warn("Unknown space unit {}", spaceAxis.getUnit());
+                }
+                xsize = spaceAxis.getScale();
+            }
+            if (axes[yind] instanceof SpaceAxes.SpaceAxis spaceAxis) {
+                if (spaceAxis.getUnit() != SpaceAxes.SpaceUnit.MICROMETER) {
+                    logger.warn("Unknown space unit {}", spaceAxis.getUnit());
+                }
+                ysize = spaceAxis.getScale();
+            }
+        }
+        double defaultValue = (xsize + ysize) / 2;
+        pixelSizeSpinner.getValueFactory().setValue(defaultValue);
+
+        // todo consider number of decimal places
+        DecimalFormat format = new DecimalFormat("0.000");
+        pixelSizeSpinner.getValueFactory().setConverter(new StringConverter<>() {
+            @Override
+            public String toString(Double value) {
+                if (value == null) return "";
+                return format.format(value);
+            }
+
+            @Override
+            public Double fromString(String string) {
+                try {
+                    return string == null || string.isEmpty() ? 0.0 : format.parse(string).doubleValue();
+                } catch (ParseException e) {
+                    return 0.0;
+                }
+            }
+        });
     }
 
     private void configureOutputClasses() {
@@ -105,7 +173,6 @@ public class BioimageIoPane extends BorderPane {
 
             if (c <= availableClasses.size())
                 comboOutputClasses.getSelectionModel().select(c-1);
-            GridPaneUtils.setToExpandGridPaneWidth(comboOutputClasses);
 
             comboOutputClasses.setTooltip(new Tooltip(resources.getString("tooltip.options.output.classes") + c));
             int ind = c - 1;
@@ -114,9 +181,13 @@ public class BioimageIoPane extends BorderPane {
                 builder.outputClasses(outputClasses);
             });
             Label label = new Label(String.format(resources.getString("ui.misc.class-n"), c));
+
+            // styling
             HBox box = new HBox(label, comboOutputClasses);
             box.setAlignment(Pos.CENTER_LEFT);
             box.getStyleClass().add("standard-spacing");
+            HBox.setHgrow(comboOutputClasses, Priority.ALWAYS);
+            comboOutputClasses.setMaxWidth(Double.MAX_VALUE);
             outputClassesBox.getChildren().add(box);
         }
 
@@ -147,11 +218,6 @@ public class BioimageIoPane extends BorderPane {
             comboChannel.getSelectionModel().select((c - 1) % availableChannels.size());
             inputChannels.add(comboChannel.getSelectionModel().getSelectedItem());
 
-            HBox box = new HBox(label, comboChannel);
-            box.setAlignment(Pos.CENTER_LEFT);
-            box.getStyleClass().add("standard-spacing");
-            GridPaneUtils.setToExpandGridPaneWidth(comboChannel);
-            this.inputChannelSelectors.getChildren().add(box);
             int ind = c - 1;
             comboChannel.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
                 if (n == null) {
@@ -161,6 +227,14 @@ public class BioimageIoPane extends BorderPane {
                 inputChannels.set(ind, n);
                 builder.inputChannels(inputChannels);
             });
+
+            // styling
+            HBox box = new HBox(label, comboChannel);
+            box.setAlignment(Pos.CENTER_LEFT);
+            box.getStyleClass().add("standard-spacing");
+            HBox.setHgrow(comboChannel, Priority.ALWAYS);
+            comboChannel.setMaxWidth(Double.MAX_VALUE);
+            this.inputChannelSelectors.getChildren().add(box);
         }
     }
 

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
@@ -1,0 +1,240 @@
+package qupath.ext.bioimageio;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.geometry.Pos;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.bioimageio.spec.Model;
+import qupath.bioimageio.spec.tensor.axes.Axes;
+import qupath.fx.utils.GridPaneUtils;
+import qupath.lib.gui.QuPathGUI;
+import qupath.lib.images.ImageData;
+import qupath.lib.images.servers.ColorTransforms;
+import qupath.lib.images.servers.ImageServerMetadata;
+import qupath.lib.objects.classes.PathClass;
+import qupath.opencv.ml.BioimageIoTools;
+import qupath.opencv.ml.PatchClassifierParams;
+
+public class BioimageIoPane extends BorderPane {
+    private final QuPathGUI qupath;
+    private static final Logger logger = LoggerFactory.getLogger(BioimageIoPane.class);
+    private static final ResourceBundle resources = ResourceBundle.getBundle("qupath.ext.bioimageio.strings");
+
+    private final PatchClassifierParams params;
+    private final PatchClassifierParams.Builder builder;
+    private final Model model;
+
+    @FXML
+    private VBox inputChannelSelectors;
+    @FXML
+    private VBox outputClassesBox;
+    @FXML
+    private ComboBox<ImageServerMetadata.ChannelType> outputTypeCombo;
+    @FXML
+    private Label fixedTileLabel;
+    @FXML
+    private VBox tileSpinnerBox;
+    @FXML
+    private Spinner<Integer> tileWidthSpinner;
+    @FXML
+    private Spinner<Integer> tileHeightSpinner;
+    @FXML
+    private VBox tileShapeOptionsBox;
+
+    /**
+     * Create an instance of the InstanSeg GUI pane.
+     *
+     * @param qupath The QuPath GUI it should be attached to.
+     * @return A handle on the UI element.
+     * @throws IOException If the FXML or resources fail to load.
+     */
+    public static BioimageIoPane createInstance(QuPathGUI qupath, Model model) throws IOException {
+        return new BioimageIoPane(qupath, model);
+    }
+
+
+    private BioimageIoPane(QuPathGUI qupath, Model model) throws IOException {
+        this.qupath = qupath;
+        var url = BioimageIoPane.class.getResource("bioimageio.fxml");
+        FXMLLoader loader = new FXMLLoader(url, resources);
+        loader.setRoot(this);
+        loader.setController(this);
+        loader.load();
+        this.model = model;
+        params = BioimageIoTools.buildPatchClassifierParams(model);
+        builder = PatchClassifierParams.builder(params);
+
+        var imageData = qupath.getImageData();
+        configureInputChannels(imageData);
+        configureTileSize();
+        configureOutputClasses();
+        configureOutputTypes();
+    }
+
+    private void configureOutputClasses() {
+        int nOutputClasses = params.getOutputClasses().size();
+
+        ObservableList<PathClass> availableClasses = FXCollections.observableArrayList();
+        if (qupath != null)
+            availableClasses = qupath.getAvailablePathClasses();
+
+        var outputClasses = new LinkedHashMap<>(params.getOutputClasses());
+        ObservableList<PathClass> classList = FXCollections.observableArrayList(outputClasses.values());
+        for (int c = 1; c <= nOutputClasses; c++) {
+            var comboOutputClasses = new ComboBox<>(classList);
+            comboOutputClasses.getItems().addAll(availableClasses);
+            comboOutputClasses.setEditable(true);
+            comboOutputClasses.setConverter(new BioimageIoCommand.PathClassStringConverter());
+
+            if (c <= availableClasses.size())
+                comboOutputClasses.getSelectionModel().select(c-1);
+            GridPaneUtils.setToExpandGridPaneWidth(comboOutputClasses);
+
+            comboOutputClasses.setTooltip(new Tooltip(resources.getString("tooltip.options.output.classes") + c));
+            int ind = c - 1;
+            comboOutputClasses.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
+                outputClasses.put(ind, n);
+                builder.outputClasses(outputClasses);
+            });
+            Label label = new Label(String.format(resources.getString("ui.misc.class-n"), c));
+            HBox box = new HBox(label, comboOutputClasses);
+            box.setAlignment(Pos.CENTER_LEFT);
+            box.getStyleClass().add("standard-spacing");
+            outputClassesBox.getChildren().add(box);
+        }
+
+    }
+
+    private void configureInputChannels(ImageData<?> imageData) {
+
+        int nChannels = params.getInputChannels().size();
+        var server = imageData.getServer();
+        ObservableList<ColorTransforms.ColorTransform> availableChannels = FXCollections.observableArrayList(
+                server.getMetadata().getChannels()
+                        .stream()
+                        .map(c -> ColorTransforms.createChannelExtractor(c.getName()))
+                        .collect(Collectors.toList()));
+        availableChannels.addAll(
+                ColorTransforms.createMeanChannelTransform(),
+                ColorTransforms.createMaximumChannelTransform(),
+                ColorTransforms.createMinimumChannelTransform()
+        );
+
+        List<ColorTransforms.ColorTransform> inputChannels = new ArrayList<>();
+
+        for (int c = 1; c <= nChannels; c++) {
+            var label = new Label(String.format(resources.getString("ui.misc.channel-n"), c));
+            var tooltip = new Tooltip(String.format(resources.getString("ui.misc.choose-channel-n"), c));
+            var comboChannel = new ComboBox<>(availableChannels);
+            comboChannel.setTooltip(tooltip);
+            comboChannel.getSelectionModel().select((c - 1) % availableChannels.size());
+            inputChannels.add(comboChannel.getSelectionModel().getSelectedItem());
+
+            HBox box = new HBox(label, comboChannel);
+            box.setAlignment(Pos.CENTER_LEFT);
+            box.getStyleClass().add("standard-spacing");
+            GridPaneUtils.setToExpandGridPaneWidth(comboChannel);
+            this.inputChannelSelectors.getChildren().add(box);
+            int ind = c - 1;
+            comboChannel.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
+                if (n == null) {
+                    logger.warn("Cannot set channel to null");
+                    return;
+                }
+                inputChannels.set(ind, n);
+                builder.inputChannels(inputChannels);
+            });
+        }
+    }
+
+
+
+
+    private void configureTileSize() {
+        // Use the patch values by default, but try to offer all the options from the model spec
+        int width = params.getPatchWidth();
+        int height = params.getPatchHeight();
+        int stepWidth = 0;
+        int stepHeight = 0;
+        if (model.getOutputs().size() == 1) {
+            var output = model.getOutputs().getFirst();
+            int[] shape = output.getShape().getShape();
+            int[] steps = output.getShape().getShapeStep();
+            int[] minSize = output.getShape().getShapeMin();
+            String outputAxes = Axes.getAxesString(output.getAxes()).toLowerCase();
+            int indX = outputAxes.indexOf("x");
+            int indY = outputAxes.indexOf("y");
+            if (indX >= 0 && indY >= 0) {
+                if (minSize.length > 0) {
+                    width = minSize[indX];
+                    height = minSize[indY];
+                } else if (shape.length > 0) {
+                    width = shape[indX];
+                    height = shape[indY];
+                }
+                if (steps.length > 0) {
+                    stepWidth = steps[indX];
+                    stepHeight = steps[indY];
+                }
+            }
+        }
+        // if fixed tile size, just display a fixed message and exit
+        if (stepWidth <= 0 && stepHeight <= 0) {
+            fixedTileLabel.setText(String.format(resources.getString("ui.options.input-tile-shape-fixed"), width, height));
+            tileShapeOptionsBox.getChildren().remove(tileSpinnerBox);
+            return;
+        }
+        tileShapeOptionsBox.getChildren().remove(fixedTileLabel);
+
+        // otherwise, configure the spinners
+        int maxTile = Math.max(width, height) * 8;
+        var factoryWidth = (SpinnerValueFactory.IntegerSpinnerValueFactory)tileWidthSpinner.getValueFactory();
+        factoryWidth.setMax(maxTile);
+        factoryWidth.setValue(params.getPatchWidth());
+        factoryWidth.setAmountToStepBy(stepWidth);
+
+        var factoryHeight = (SpinnerValueFactory.IntegerSpinnerValueFactory)tileHeightSpinner.getValueFactory();
+        factoryHeight.setMax(maxTile);
+        factoryHeight.setValue(params.getPatchHeight());
+        factoryHeight.setAmountToStepBy(stepHeight);
+
+        tileWidthSpinner.valueProperty().addListener((v, o, n) -> builder.patchSize(tileWidthSpinner.getValue(), tileHeightSpinner.getValue()));
+        tileHeightSpinner.valueProperty().addListener((v, o, n) -> builder.patchSize(tileWidthSpinner.getValue(), tileHeightSpinner.getValue()));
+        GridPaneUtils.setToExpandGridPaneWidth(tileWidthSpinner, tileHeightSpinner); // todo replace these calls with FXML settings
+    }
+
+    private void configureOutputTypes() {
+        outputTypeCombo.getItems().clear();
+        outputTypeCombo.getItems().addAll(
+                ImageServerMetadata.ChannelType.PROBABILITY,
+                ImageServerMetadata.ChannelType.MULTICLASS_PROBABILITY,
+                ImageServerMetadata.ChannelType.CLASSIFICATION
+        );
+        outputTypeCombo.getSelectionModel().select(params.getOutputChannelType());
+        outputTypeCombo.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
+            if (n != null)
+                builder.outputChannelType(n);
+            else
+                logger.warn("Output type cannot be null");
+        });
+        GridPaneUtils.setToExpandGridPaneWidth(outputTypeCombo); // todo replaceme
+    }
+
+}

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
@@ -154,7 +154,6 @@ public class BioimageIoPane extends BorderPane {
         double defaultValue = (xsize + ysize) / 2;
         pixelSizeSpinner.getValueFactory().setValue(defaultValue);
 
-        // todo consider number of decimal places
         DecimalFormat format = new DecimalFormat("0.000");
         pixelSizeSpinner.getValueFactory().setConverter(new StringConverter<>() {
             @Override
@@ -309,7 +308,6 @@ public class BioimageIoPane extends BorderPane {
 
         tileWidthSpinner.valueProperty().addListener((v, o, n) -> builder.patchSize(tileWidthSpinner.getValue(), tileHeightSpinner.getValue()));
         tileHeightSpinner.valueProperty().addListener((v, o, n) -> builder.patchSize(tileWidthSpinner.getValue(), tileHeightSpinner.getValue()));
-        GridPaneUtils.setToExpandGridPaneWidth(tileWidthSpinner, tileHeightSpinner); // todo replace these calls with FXML settings
     }
 
     private void configureOutputTypes() {
@@ -326,7 +324,6 @@ public class BioimageIoPane extends BorderPane {
             else
                 logger.warn("Output type cannot be null");
         });
-        GridPaneUtils.setToExpandGridPaneWidth(outputTypeCombo); // todo replaceme
     }
 
 }

--- a/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
+++ b/src/main/java/qupath/ext/bioimageio/BioimageIoPane.java
@@ -13,6 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Pos;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
@@ -66,6 +67,8 @@ public class BioimageIoPane extends BorderPane {
     private VBox tileShapeOptionsBox;
     @FXML
     private Spinner<Double> pixelSizeSpinner;
+    @FXML
+    private Button imageJButton;
 
 
     public static PatchClassifierParams createDialog(QuPathGUI qupath, Model model) {
@@ -111,6 +114,21 @@ public class BioimageIoPane extends BorderPane {
         configurePixelSize(model);
         configureOutputClasses();
         configureOutputTypes();
+        configureImageJButton();
+    }
+
+    private void configureImageJButton() {
+        var tester = new BioimageIoCommand.BioimageIoTest(model);
+        if (tester.hasInput()) {
+            var btnTest = new Button("Show test images in ImageJ");
+            btnTest.setOnAction(e -> tester.runAndShowOutput(params));
+            GridPaneUtils.addGridRow(pane, row++, 0,
+                    "Attempt to run prediction on the test image, if available.\n"
+                            + "This checks the model runes, but does not use most of the customizations here\n"
+                            + "because the channel input is fixed.",
+                    btnTest, btnTest);
+            GridPaneUtils.setToExpandGridPaneWidth(btnTest);
+        }
     }
 
     private void configurePixelSize(Model model) {

--- a/src/main/java/qupath/ext/bioimageio/strings.properties
+++ b/src/main/java/qupath/ext/bioimageio/strings.properties
@@ -1,2 +1,0 @@
-action = Create pixel classifier (Bioimage Model Zoo)
-action.description = Import a pixel classifier from a bioimage.io package.

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.css
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.css
@@ -1,0 +1,54 @@
+/* Title */
+.bioimageio-title {
+    /*-fx-font-size: 150%;*/
+    -fx-font-weight: bold;
+    -fx-text-fill: -fx-text-base-color;
+}
+
+/* Sub-title */
+.bioimageio-subtitle {
+    -fx-text-fill: -fx-text-base-color;
+    -fx-font-weight: bold;
+    -fx-padding: 10 0 10 0;
+    -fx-opacity:0.6;
+    /*-fx-font-style: italic;*/
+    /*-fx-padding: -7.5;*/
+}
+
+/* message-label-styles */
+.warning-message {
+    -fx-text-fill: -qp-script-error-color;
+    -fx-opacity:0.8;
+    -fx-font-style: italic;
+}
+.standard-message {
+    -fx-text-fill: -fx-text-base-color;
+    -fx-opacity:0.6;
+    -fx-font-style: italic;
+}
+
+/* separator */
+.bioimageio .separator {
+    -fx-line-color: -fx-text-base-color;
+    -fx-padding: 15;
+}
+
+/* spacing - current use in HBox*/
+.standard-spacing {
+    -fx-spacing: 7.5;
+}
+
+/* spacing - current use in VBox*/
+.standard-vertical-spacing {
+    -fx-spacing: 5;
+}
+
+.standard-padding {
+    -fx-padding: 2;
+}
+
+.fa-icon {
+    -fx-font-family: FontAwesome;
+    -fx-font-size: 14px;
+    -fx-fill: -fx-text-base-color;
+}

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.css
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.css
@@ -1,6 +1,5 @@
 /* Title */
 .bioimageio-title {
-    /*-fx-font-size: 150%;*/
     -fx-font-weight: bold;
     -fx-text-fill: -fx-text-base-color;
 }
@@ -11,26 +10,6 @@
     -fx-font-weight: bold;
     -fx-padding: 10 0 10 0;
     -fx-opacity:0.6;
-    /*-fx-font-style: italic;*/
-    /*-fx-padding: -7.5;*/
-}
-
-/* message-label-styles */
-.warning-message {
-    -fx-text-fill: -qp-script-error-color;
-    -fx-opacity:0.8;
-    -fx-font-style: italic;
-}
-.standard-message {
-    -fx-text-fill: -fx-text-base-color;
-    -fx-opacity:0.6;
-    -fx-font-style: italic;
-}
-
-/* separator */
-.bioimageio .separator {
-    -fx-line-color: -fx-text-base-color;
-    -fx-padding: 15;
 }
 
 /* spacing - current use in HBox*/

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.*?>
+
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.control.SpinnerValueFactory.DoubleSpinnerValueFactory?>
+<?import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Tooltip?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.cell.ComboBoxListCell?>
+<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="330" stylesheets="@bioimageio.css" type="BorderPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+    <center>
+        <VBox styleClass="standard-spacing,standard-padding">
+            <TitledPane text="%ui.section.experimental" animated="false" collapsible="false" prefWidth="330.0" styleClass="uncollapsible-titled-pane,bioimageio-title">
+                <VBox styleClass="standard-spacing,standard-padding">
+                    <Label text="%ui.section.experimental-warning" wrapText="true"/>
+                </VBox>
+            </TitledPane>
+            <TitledPane text="%ui.section.input" animated="false" prefWidth="330.0" styleClass="standard-spacing">
+                <VBox>
+                    <VBox>
+                        <Label text="%ui.section.input-channels" styleClass="bioimageio-subtitle"/>
+                        <VBox fx:id="inputChannelSelectors" />
+                    </VBox>
+                    <VBox styleClass="standard-spacing">
+                        <Label text="%ui.section.input-resolution" styleClass="bioimageio-subtitle"/>
+                        <HBox alignment="CENTER_LEFT" styleClass="standard-spacing">
+                            <Label text="%ui.section.input-resolution-description" wrapText="true"/>
+                            <Spinner fx:id="pixelSizeSpinner" prefWidth="75.0">
+                                <tooltip>
+                                    <Tooltip text="%options.pixel-size" />
+                                </tooltip>
+                                <valueFactory>
+                                    <SpinnerValueFactory.DoubleSpinnerValueFactory min="0.001" max="5" amountToStepBy="0.01"/>
+                                </valueFactory>
+                            </Spinner>
+                        </HBox>
+                    </VBox>
+                    <VBox fx:id="tileShapeOptionsBox">
+    <!--                    todo: create tile options, show and hide as appropriate -->
+                        <Label text="%ui.section.input-tile-shape" styleClass="bioimageio-subtitle"/>
+                        <Label fx:id="fixedTileLabel" text="%ui.options.input-tile-shape-fixed" />
+                        <VBox fx:id="tileSpinnerBox">
+                            <HBox>
+                                <Label text="%ui.options.input-tile-width"/>
+                                <Spinner fx:id="tileWidthSpinner" editable="false">
+                                    <tooltip>
+                                        <Tooltip text="%tooltip.options.input-tile-width" />
+                                    </tooltip>
+                                    <valueFactory>
+                                        <SpinnerValueFactory.IntegerSpinnerValueFactory min="1" max="2048"/>
+                                    </valueFactory>
+                                </Spinner>
+                            </HBox>
+                            <HBox>
+                                <Label text="%ui.options.input-tile-height" styleClass="bioimageio-subtitle"/>
+                                <Spinner fx:id="tileHeightSpinner" editable="false">
+                                    <tooltip>
+                                        <Tooltip text="%tooltip.options.input-tile-height" />
+                                    </tooltip>
+                                    <valueFactory>
+                                        <SpinnerValueFactory.IntegerSpinnerValueFactory min="1" max="2048" />
+                                    </valueFactory>
+                                </Spinner>
+                            </HBox>
+                        </VBox>
+                    </VBox>
+                </VBox>
+            </TitledPane>
+            <TitledPane animated="false" prefWidth="330.0" text="%ui.section.output" >
+                <VBox styleClass="standard-spacing,standard-padding">
+                    <Label text="%ui.section.output-classes" styleClass="bioimageio-subtitle"/>
+                    <Label text="%ui.options.output-classes-description" />
+                    <VBox fx:id="outputClassesBox" />
+                    <Label text="%ui.section.output-type" styleClass="bioimageio-subtitle"/>
+                    <Label text="%ui.section.output-type-choose"/>
+                    <HBox>
+                        <ComboBox fx:id="outputTypeCombo"/>
+                    </HBox>
+                </VBox>
+            </TitledPane>
+            <VBox styleClass="standard-spacing,standard-padding">
+                <Button text="%ui.section.imagej" maxWidth="Infinity">
+                    <tooltip>
+                        <Tooltip text="%tooltip.section.imagej"/>
+                    </tooltip>
+                </Button>
+            </VBox>
+        </VBox>
+    </center>
+</fx:root>

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.control.Button?>
 
-<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="380.0" stylesheets="@bioimageio.css" type="BorderPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="380.0" stylesheets="@bioimageio.css" style="-fx-padding: 5" type="BorderPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
     <center>
         <VBox>
             <TitledPane text="%ui.section.experimental" animated="false" collapsible="false" prefWidth="380.0" prefHeight="150.0"  styleClass="uncollapsible-titled-pane,bioimageio-title" VBox.vgrow="NEVER">
@@ -25,7 +25,7 @@
                         <Label text="%ui.section.input-channels" styleClass="bioimageio-subtitle"/>
                         <VBox fx:id="inputChannelSelectors" />
                     </VBox>
-                    <VBox styleClass="standard-spacing">
+                    <VBox >
                         <Label text="%ui.section.input-resolution" styleClass="bioimageio-subtitle"/>
                         <HBox alignment="CENTER_LEFT" styleClass="standard-spacing">
                             <Label text="%ui.section.input-resolution-description" wrapText="true"/>
@@ -71,7 +71,7 @@
                 </VBox>
             </TitledPane>
             <TitledPane animated="false" prefWidth="380.0" text="%ui.section.output" VBox.vgrow="NEVER">
-                <VBox styleClass="standard-spacing,standard-padding">
+                <VBox styleClass="standard-spacing">
                     <Label text="%ui.section.output-classes" styleClass="bioimageio-subtitle" wrapText="true"/>
                     <Label text="%ui.options.output-classes-description" />
                     <VBox fx:id="outputClassesBox" />
@@ -82,7 +82,7 @@
                     </HBox>
                 </VBox>
             </TitledPane>
-            <VBox styleClass="standard-spacing,standard-padding">
+            <VBox>
                 <Button fx:id="imageJButton" text="%ui.section.imagej" maxWidth="Infinity">
                     <tooltip>
                         <Tooltip text="%tooltip.section.imagej"/>

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
@@ -40,7 +40,6 @@
                         </HBox>
                     </VBox>
                     <VBox fx:id="tileShapeOptionsBox">
-    <!--                    todo: create tile options, show and hide as appropriate -->
                         <Label text="%ui.section.input-tile-shape" styleClass="bioimageio-subtitle"/>
                         <Label fx:id="fixedTileLabel" text="%ui.options.input-tile-shape-fixed" />
                         <VBox fx:id="tileSpinnerBox">

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
@@ -4,23 +4,22 @@
 
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.Spinner?>
 <?import javafx.scene.control.SpinnerValueFactory.DoubleSpinnerValueFactory?>
 <?import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.cell.ComboBoxListCell?>
-<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="330" stylesheets="@bioimageio.css" type="BorderPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+
+<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="380.0" stylesheets="@bioimageio.css" type="BorderPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
     <center>
-        <VBox styleClass="standard-spacing,standard-padding">
-            <TitledPane text="%ui.section.experimental" animated="false" collapsible="false" prefWidth="330.0" styleClass="uncollapsible-titled-pane,bioimageio-title">
+        <VBox>
+            <TitledPane text="%ui.section.experimental" animated="false" collapsible="false" prefWidth="380.0" prefHeight="150.0"  styleClass="uncollapsible-titled-pane,bioimageio-title" VBox.vgrow="NEVER">
                 <VBox styleClass="standard-spacing,standard-padding">
                     <Label text="%ui.section.experimental-warning" wrapText="true"/>
                 </VBox>
             </TitledPane>
-            <TitledPane text="%ui.section.input" animated="false" prefWidth="330.0" styleClass="standard-spacing">
+            <TitledPane text="%ui.section.input" animated="false" prefWidth="380.0" VBox.vgrow="NEVER">
                 <VBox>
                     <VBox>
                         <Label text="%ui.section.input-channels" styleClass="bioimageio-subtitle"/>
@@ -30,12 +29,12 @@
                         <Label text="%ui.section.input-resolution" styleClass="bioimageio-subtitle"/>
                         <HBox alignment="CENTER_LEFT" styleClass="standard-spacing">
                             <Label text="%ui.section.input-resolution-description" wrapText="true"/>
-                            <Spinner fx:id="pixelSizeSpinner" prefWidth="75.0">
+                            <Spinner fx:id="pixelSizeSpinner" prefWidth="100.0" >
                                 <tooltip>
                                     <Tooltip text="%options.pixel-size" />
                                 </tooltip>
                                 <valueFactory>
-                                    <SpinnerValueFactory.DoubleSpinnerValueFactory min="0.001" max="5" amountToStepBy="0.01"/>
+                                    <SpinnerValueFactory.DoubleSpinnerValueFactory min="0.01" max="5" initialValue="0.25" amountToStepBy="0.001"/>
                                 </valueFactory>
                             </Spinner>
                         </HBox>
@@ -71,15 +70,15 @@
                     </VBox>
                 </VBox>
             </TitledPane>
-            <TitledPane animated="false" prefWidth="330.0" text="%ui.section.output" >
+            <TitledPane animated="false" prefWidth="380.0" text="%ui.section.output" VBox.vgrow="NEVER">
                 <VBox styleClass="standard-spacing,standard-padding">
-                    <Label text="%ui.section.output-classes" styleClass="bioimageio-subtitle"/>
+                    <Label text="%ui.section.output-classes" styleClass="bioimageio-subtitle" wrapText="true"/>
                     <Label text="%ui.options.output-classes-description" />
                     <VBox fx:id="outputClassesBox" />
                     <Label text="%ui.section.output-type" styleClass="bioimageio-subtitle"/>
                     <Label text="%ui.section.output-type-choose"/>
                     <HBox>
-                        <ComboBox fx:id="outputTypeCombo"/>
+                        <ComboBox fx:id="outputTypeCombo" maxWidth="Infinity" HBox.hgrow="ALWAYS"/>
                     </HBox>
                 </VBox>
             </TitledPane>

--- a/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
+++ b/src/main/resources/qupath/ext/bioimageio/bioimageio.fxml
@@ -83,7 +83,7 @@
                 </VBox>
             </TitledPane>
             <VBox styleClass="standard-spacing,standard-padding">
-                <Button text="%ui.section.imagej" maxWidth="Infinity">
+                <Button fx:id="imageJButton" text="%ui.section.imagej" maxWidth="Infinity">
                     <tooltip>
                         <Tooltip text="%tooltip.section.imagej"/>
                     </tooltip>

--- a/src/main/resources/qupath/ext/bioimageio/strings.properties
+++ b/src/main/resources/qupath/ext/bioimageio/strings.properties
@@ -1,0 +1,41 @@
+title = Create pixel classifier (Bioimage Model Zoo)
+action = Create pixel classifier (Bioimage Model Zoo)
+action.description = Import a pixel classifier from a bioimage.io package.
+
+ui.section.experimental = Experimental - use with caution!
+ui.section.experimental-warning = This command tries to create a QuPath pixel classifier from a BioImage Model Zoo spec.\
+  It may not work in all (or even most) cases.\
+  It can also sometimes give different results to other software, because of different per-tile normalization.
+ui.section.input = Input
+ui.section.input-channels = Input channels
+
+ui.section.input-resolution = Input resolution
+ui.section.input-resolution-description = Requested input pixel size
+options.pixel-size = The pixel size in microns at which the model will be applied
+
+ui.section.input-tile-shape = Input tile shape
+ui.options.input-tile-shape-fixed = Tile size fixed to [%d, %d]
+ui.options.input-tile-width = Input tile width
+tooltip.options.input-tile-width = Choose input tile width in pixels
+ui.options.input-tile-height = Input tile height
+tooltip.options.input-tile-height = Choose input tile height in pixels
+
+
+ui.section.output = Output
+
+ui.section.output-classes = Output classes
+tooltip.options.output.classes = Choose output classification for channel
+ui.options.output-classes-description = The classifications corresponding to the model output
+
+ui.section.output-type = Output type
+ui.section.output-type-choose = The output type of the model
+
+ui.section.imagej = Show test images in ImageJ
+tooltip.section.imagej = Attempt to run prediction on the test image, if available.\
+    This checks the model runes, but does not use most of the customizations here\
+    because the channel input is fixed.
+
+ui.misc.class-n = Class %d
+ui.misc.channel-n = Channel %d
+ui.misc.choose-channel-n = Choose channel %d input
+

--- a/src/main/resources/qupath/ext/bioimageio/strings.properties
+++ b/src/main/resources/qupath/ext/bioimageio/strings.properties
@@ -3,8 +3,8 @@ action = Create pixel classifier (Bioimage Model Zoo)
 action.description = Import a pixel classifier from a bioimage.io package.
 
 ui.section.experimental = Experimental - use with caution!
-ui.section.experimental-warning = This command tries to create a QuPath pixel classifier from a BioImage Model Zoo spec.\
-  It may not work in all (or even most) cases.\
+ui.section.experimental-warning = This command tries to create a QuPath pixel classifier from a BioImage Model Zoo spec. \n\
+  It may not work in all (or even most) cases. \n\
   It can also sometimes give different results to other software, because of different per-tile normalization.
 ui.section.input = Input
 ui.section.input-channels = Input channels


### PR DESCRIPTION
Some instances remain intertwined by necessity as they depend on the structure of the model.

CI fails because the qupath catalog is still on 0.2.0, where I made some API changes in 0.2.1 (arguably should be 0.3.0 but...)

old:
<img width="581" height="799" alt="Screenshot from 2026-04-16 11-57-36" src="https://github.com/user-attachments/assets/6c29e5e8-380c-439e-8ae1-6c2a4ddb38f5" />

new: <img width="420" height="837" alt="image" src="https://github.com/user-attachments/assets/f2296510-8e00-4b04-951e-c0bab20989aa" />